### PR TITLE
feat: set server as authoritative

### DIFF
--- a/server.go
+++ b/server.go
@@ -145,6 +145,7 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, m *dns.Msg) {
 
 	reply.SetReply(m)
 	reply.RecursionAvailable = true
+	reply.Authoritative = true
 
 	q := m.Question[0]
 


### PR DESCRIPTION
Hi!

The answers of the server are not seen as authoritative whereas they should. Because it's the goal of the project no?

Thx,

Pierre