### PR TITLE
feat: set server as authoritative

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -31,7 +31,7 @@ func ExampleServer_PatchNet() {
 		"example.org.": {
 			A: []string{"1.2.3.4"},
 		},
-	})
+	}, false)
 	defer srv.Close()
 
 	srv.PatchNet(net.DefaultResolver)


### PR DESCRIPTION
Hi!

The answers of the server are not seen as authoritative whereas they should. Because it's the goal of the project no?

Thx,

Pierre