### PR TITLE
Adapting to Resolver.LookupNetIP which supported in go 1.18

### DIFF
--- a/resolver_go1.18.go
+++ b/resolver_go1.18.go
@@ -1,0 +1,42 @@
+//go:build go1.18
+// +build go1.18
+
+package mockdns
+
+import (
+	"context"
+	"fmt"
+
+	"net/netip"
+)
+
+func (r *Resolver) LookupNetIP(ctx context.Context, network, host string) ([]netip.Addr, error) {
+	var addrs []string
+	var err error
+	switch network {
+	case "ip":
+		addrs, err = r.LookupHost(ctx, host)
+	case "ip4":
+		_, addrs, err = r.lookupA(ctx, host)
+	case "ip6":
+		_, addrs, err = r.lookupAAAA(ctx, host)
+	default:
+		return nil, fmt.Errorf("unsupported network: %v", network)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if len(addrs) == 0 {
+		return nil, notFound(host)
+	}
+
+	parsed := make([]netip.Addr, len(addrs))
+	for i, addr := range addrs {
+		parsed[i], err = netip.ParseAddr(addr)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return parsed, nil
+}

--- a/resolver_go1.18_test.go
+++ b/resolver_go1.18_test.go
@@ -1,0 +1,58 @@
+//go:build go1.18
+// +build go1.18
+
+package mockdns
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestResolver_LookupNetIP(t *testing.T) {
+	r := &Resolver{Zones: map[string]Zone{
+		"example.com.": {
+			A:    []string{"192.168.0.1", "10.0.0.1"},
+			AAAA: []string{"2001:db8::1", "2001:db8::2"},
+		},
+		"example.org.": {
+			MX: []net.MX{
+				{Host: "example.com.", Pref: 10},
+			},
+		},
+	}}
+	cases := []struct {
+		name    string
+		network string
+		host    string
+		want    []string
+		wantErr bool
+	}{
+		{name: "IPv4 Only", network: "ip4", host: "example.com", want: []string{"192.168.0.1", "10.0.0.1"}, wantErr: false},
+		{name: "IPv6 Only", network: "ip6", host: "example.com", want: []string{"2001:db8::1", "2001:db8::2"}, wantErr: false},
+		{name: "IPv4&IPv6", network: "ip", host: "example.com", want: []string{"192.168.0.1", "10.0.0.1", "2001:db8::1", "2001:db8::2"}, wantErr: false},
+		{name: "IPv4 Not Found", network: "ip4", host: "example.org", want: []string{}, wantErr: true},
+		{name: "IPv6 Not Found", network: "ip6", host: "example.org", want: []string{}, wantErr: true},
+		{name: "IPv4&IPv6 Not Found", network: "ip", host: "example.org", want: []string{}, wantErr: true},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := r.LookupNetIP(context.Background(), tt.network, tt.host)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Wrong error, want %v, got %v", tt.wantErr, err)
+			}
+			items := make([]string, len(got))
+			for i, ip := range got {
+				items[i] = ip.String()
+			}
+			sort.Strings(items)
+			sort.Strings(tt.want)
+			if !reflect.DeepEqual(items, tt.want) {
+				t.Errorf("Wrong result, want %v, got %v", tt.want, items)
+			}
+		})
+
+	}
+}


### PR DESCRIPTION
Since the package "netip" was also added in go1.18, put it in a file with build tag "go1.18"

https://pkg.go.dev/net#Resolver.LookupNetIP
https://github.com/golang/go/commit/a59e33224e42d60a97fa720a45e1b74eb6aaa3d0